### PR TITLE
Add NFL scoreboard and routing

### DIFF
--- a/app/nfl-game/page.tsx
+++ b/app/nfl-game/page.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import { FootballScoreboard } from "@/features/football"
+import type { FootballGame } from "@/features/football"
+
+export default function NflGamePage() {
+  const game: FootballGame = {
+    homeTeam: {
+      name: "Dallas Cowboys",
+      abbreviation: "DAL",
+      logo: "/dallas-cowboys-logo.png",
+      score: 17,
+    },
+    awayTeam: {
+      name: "New York Giants",
+      abbreviation: "NYG",
+      logo: "/new-york-giants-logo.png",
+      score: 10,
+    },
+    quarter: "4th",
+    timeRemaining: "12:34",
+    down: "2nd",
+    distance: "7",
+    possession: "home",
+    stats: {
+      timeouts: [2, 3],
+      passing: {
+        away: { completions: 14, attempts: 28, yards: 192 },
+        home: { completions: 18, attempts: 33, yards: 245 },
+      },
+      rushing: {
+        away: {
+          attempts: 18,
+          yards: 82,
+          players: [
+            { name: "RB A", attempts: 10, yards: 45 },
+            { name: "RB B", attempts: 8, yards: 37 },
+          ],
+        },
+        home: {
+          attempts: 22,
+          yards: 105,
+          players: [
+            { name: "RB C", attempts: 12, yards: 60 },
+            { name: "RB D", attempts: 10, yards: 45 },
+          ],
+        },
+      },
+      quarterScores: [
+        { period: "1", scores: [3, 7] },
+        { period: "2", scores: [7, 7] },
+        { period: "Half", scores: [10, 14] },
+        { period: "3", scores: [0, 3] },
+        { period: "4", scores: [0, 0] },
+        { period: "Total", scores: [10, 17] },
+      ],
+    },
+  }
+
+  return (
+    <div className="bg-[#fafafa] min-h-screen text-[#2b2c2d] p-4">
+      <Link href="/" className="flex items-center gap-2 mb-4 text-[#5f6368] hover:text-[#2b2c2d]">
+        <ArrowLeft className="h-4 w-4" />
+        <span>Back to fixtures</span>
+      </Link>
+      <FootballScoreboard game={game} />
+    </div>
+  )
+}

--- a/features/fixtures/components/FixtureTable.tsx
+++ b/features/fixtures/components/FixtureTable.tsx
@@ -47,8 +47,12 @@ export function FixtureTable({ fixtures, isLoading, onTogglePin, onRefresh }: Fi
     }
   })
 
-  const handleFixtureClick = (fixtureId: string) => {
-    router.push(`/game?id=${fixtureId}`)
+  const handleFixtureClick = (fixtureId: string, sport: string) => {
+    if (sport === "football") {
+      router.push(`/nfl-game?id=${fixtureId}`)
+    } else {
+      router.push(`/game?id=${fixtureId}`)
+    }
   }
 
   const getSportIcon = (sport: string) => {
@@ -249,7 +253,7 @@ export function FixtureTable({ fixtures, isLoading, onTogglePin, onRefresh }: Fi
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => handleFixtureClick(fixture.id)}
+                      onClick={() => handleFixtureClick(fixture.id, fixture.sport)}
                       className="text-blue-600"
                     >
                       View

--- a/features/football/components/FootballScoreboard.tsx
+++ b/features/football/components/FootballScoreboard.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import type { FootballGame } from "../types"
+import { RushingTooltip } from "./RushingTooltip"
+
+interface FootballScoreboardProps {
+  game: FootballGame
+}
+
+export function FootballScoreboard({ game }: FootballScoreboardProps) {
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">NFL Live</h1>
+          <p className="text-gray-600">Week 12 • Sunday</p>
+        </div>
+
+        {/* Team Logos and Score */}
+        <div className="flex justify-between items-center mb-6">
+          <div className="flex flex-col items-center">
+            <img
+              src={game.awayTeam.logo || "/placeholder.svg"}
+              alt={game.awayTeam.name}
+              width={80}
+              height={80}
+              className="rounded-lg mb-2"
+            />
+            <span className="text-sm text-gray-600 font-medium">{game.awayTeam.name}</span>
+          </div>
+
+          <div className="text-6xl font-bold text-center text-gray-900">
+            {game.awayTeam.score} - {game.homeTeam.score}
+          </div>
+
+          <div className="flex flex-col items-center">
+            <img
+              src={game.homeTeam.logo || "/placeholder.svg"}
+              alt={game.homeTeam.name}
+              width={80}
+              height={80}
+              className="rounded-lg mb-2"
+            />
+            <span className="text-sm text-gray-600 font-medium">{game.homeTeam.name}</span>
+          </div>
+        </div>
+
+        {/* Game Status */}
+        <div className="flex justify-between items-center mb-8">
+          <div className="text-2xl font-bold text-orange-600">{game.awayTeam.abbreviation}</div>
+
+          <div className="text-center">
+            <div className="text-xl text-gray-700 font-semibold">
+              {game.quarter} Quarter • {game.timeRemaining}
+            </div>
+            {game.down && game.distance && (
+              <div className="text-lg text-gray-900 mt-1">
+                {game.down} & {game.distance}
+                {game.possession && (
+                  <span className="ml-2 text-sm text-orange-600 font-medium">
+                    ({game.possession === "home" ? game.homeTeam.abbreviation : game.awayTeam.abbreviation} ball)
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="text-2xl font-bold">{game.homeTeam.abbreviation}</div>
+        </div>
+
+        {/* Stats Table */}
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden mb-6">
+          {/* Timeouts */}
+          <div className="grid grid-cols-3 border-b border-gray-200 bg-gray-50">
+            <div className="text-center py-4 font-semibold text-lg">{game.stats.timeouts[0]}</div>
+            <div className="text-center py-4 font-bold text-gray-700">Timeouts</div>
+            <div className="text-center py-4 font-semibold text-lg">{game.stats.timeouts[1]}</div>
+          </div>
+
+          {/* Passing */}
+          <div className="grid grid-cols-3 border-b border-gray-200">
+            <div className="text-center py-4 font-mono text-lg">
+              {game.stats.passing.away.completions}/{game.stats.passing.away.attempts}, {game.stats.passing.away.yards}
+            </div>
+            <div className="text-center py-4 font-bold text-gray-700">Passing</div>
+            <div className="text-center py-4 font-mono text-lg">
+              {game.stats.passing.home.completions}/{game.stats.passing.home.attempts}, {game.stats.passing.home.yards}
+            </div>
+          </div>
+
+          {/* Rushing with Hover */}
+          <div className="grid grid-cols-3">
+            <div className="text-center py-4">
+              <RushingTooltip players={game.stats.rushing.away.players}>
+                <span className="font-mono text-lg">
+                  {game.stats.rushing.away.attempts}-{game.stats.rushing.away.yards}
+                </span>
+              </RushingTooltip>
+            </div>
+
+            <div className="text-center py-4 font-bold text-gray-700">Rushing</div>
+
+            <div className="text-center py-4">
+              <RushingTooltip players={game.stats.rushing.home.players}>
+                <span className="font-mono text-lg">
+                  {game.stats.rushing.home.attempts}-{game.stats.rushing.home.yards}
+                </span>
+              </RushingTooltip>
+            </div>
+          </div>
+        </div>
+
+        {/* Quarter Scores */}
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 bg-gray-50">
+                  <th className="py-3 px-4 text-left font-medium"></th>
+                  {game.stats.quarterScores.map((quarter, index) => (
+                    <th key={index} className="py-3 px-4 text-center font-medium">
+                      {quarter.period === "Total" ? "Total" : quarter.period}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b border-gray-200">
+                  <td className="py-3 px-4 text-left text-orange-600 font-medium flex items-center">
+                    <span className="inline-block w-2 h-2 rounded-full bg-orange-600 mr-2"></span>
+                    {game.awayTeam.abbreviation}
+                  </td>
+                  {game.stats.quarterScores.map((quarter, index) => (
+                    <td
+                      key={index}
+                      className={`py-3 px-4 text-center ${
+                        quarter.period === "Half" || quarter.period === "Total" ? "text-orange-600 font-medium" : ""
+                      }`}
+                    >
+                      {quarter.scores[0]}
+                    </td>
+                  ))}
+                </tr>
+                <tr>
+                  <td className="py-3 px-4 text-left font-medium">{game.homeTeam.abbreviation}</td>
+                  {game.stats.quarterScores.map((quarter, index) => (
+                    <td
+                      key={index}
+                      className={`py-3 px-4 text-center ${
+                        quarter.period === "Half" || quarter.period === "Total" ? "font-medium" : ""
+                      }`}
+                    >
+                      {quarter.scores[1]}
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Helper Text */}
+        <div className="mt-4 text-center text-sm text-gray-500">
+          💡 Hover over rushing stats to see individual player breakdowns
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/features/football/components/RushingTooltip.tsx
+++ b/features/football/components/RushingTooltip.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { ReactNode } from "react"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import type { RushingPlayer } from "../types"
+
+interface RushingTooltipProps {
+  players: RushingPlayer[]
+  children: ReactNode
+}
+
+export function RushingTooltip({ players, children }: RushingTooltipProps) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent>
+          <div className="text-left space-y-1">
+            {players.map((p, i) => (
+              <div key={i}>
+                {p.name}: {p.attempts} for {p.yards}
+              </div>
+            ))}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/features/football/index.ts
+++ b/features/football/index.ts
@@ -1,0 +1,3 @@
+export * from "./components/FootballScoreboard"
+export * from "./components/RushingTooltip"
+export * from "./types"

--- a/features/football/types/index.ts
+++ b/features/football/types/index.ts
@@ -1,0 +1,51 @@
+export interface FootballTeam {
+  name: string
+  abbreviation: string
+  logo?: string
+  score: number
+}
+
+export interface PassingStats {
+  completions: number
+  attempts: number
+  yards: number
+}
+
+export interface RushingPlayer {
+  name: string
+  attempts: number
+  yards: number
+}
+
+export interface RushingStats {
+  attempts: number
+  yards: number
+  players: RushingPlayer[]
+}
+
+export interface FootballGameStats {
+  timeouts: [number, number]
+  passing: {
+    away: PassingStats
+    home: PassingStats
+  }
+  rushing: {
+    away: RushingStats
+    home: RushingStats
+  }
+  quarterScores: {
+    period: string
+    scores: [number, number]
+  }[]
+}
+
+export interface FootballGame {
+  homeTeam: FootballTeam
+  awayTeam: FootballTeam
+  quarter: string
+  timeRemaining: string
+  down?: string
+  distance?: string
+  possession?: "home" | "away"
+  stats: FootballGameStats
+}


### PR DESCRIPTION
## Summary
- add new NFL scoreboard components and types
- create a dedicated NFL game page using the new scoreboard
- route football fixtures to the NFL game page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853bb60bcc883289a9ef0c571fcec25