### PR TITLE
Integrate sample markets into Confidence UI

### DIFF
--- a/app/model-configuration/page.tsx
+++ b/app/model-configuration/page.tsx
@@ -6,12 +6,12 @@ import TopNavigation from "@/components/top-navigation"
 import { Card, CardContent } from "@/components/ui/card"
 import { Select, SelectTrigger, SelectContent, SelectItem } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { AutoLineMovementView } from "@/features/auto-line-mover"
 import { sportsData } from "@/features/auto-line-mover/data"
 
-const mockMarkets = sportsData
+const allMockMarkets = sportsData
   .flatMap((sport) => sport.categories.flatMap((c) => c.markets))
-  .slice(0, 8)
   .map((m, idx) => ({
     marketId: m.id,
     event: m.name,
@@ -28,6 +28,8 @@ const mockMarkets = sportsData
     endorsed: true,
   }))
 
+const INITIAL_LOAD = 8
+
 const confidenceColors: Record<string, string> = {
   High: 'bg-green-500',
   Medium: 'bg-yellow-400',
@@ -35,7 +37,12 @@ const confidenceColors: Record<string, string> = {
 }
 
 function ConfidenceInputUI() {
-  const [markets, setMarkets] = useState(mockMarkets)
+  const [markets, setMarkets] = useState(allMockMarkets.slice(0, INITIAL_LOAD))
+
+  const loadMoreMarkets = () => {
+    const next = allMockMarkets.slice(markets.length, markets.length + INITIAL_LOAD)
+    if (next.length) setMarkets([...markets, ...next])
+  }
 
   const handleConfidenceChange = (marketId: string, newConfidence: string) => {
     const updated = markets.map((market) =>
@@ -93,6 +100,11 @@ function ConfidenceInputUI() {
           </CardContent>
         </Card>
       ))}
+      {markets.length < allMockMarkets.length && (
+        <Button variant="outline" onClick={loadMoreMarkets} className="w-full">
+          Load more markets
+        </Button>
+      )}
     </div>
   )
 }

--- a/app/model-configuration/page.tsx
+++ b/app/model-configuration/page.tsx
@@ -6,6 +6,7 @@ import TopNavigation from "@/components/top-navigation"
 import { Card, CardContent } from "@/components/ui/card"
 import { Select, SelectTrigger, SelectContent, SelectItem } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
+import { AutoLineMovementView } from "@/features/auto-line-mover"
 import { sportsData } from "@/features/auto-line-mover/data"
 
 const mockMarkets = sportsData
@@ -96,80 +97,6 @@ function ConfidenceInputUI() {
   )
 }
 
-// Placeholder components for the Model Configuration sections
-const AutoLineMovementConfig = () => (
-  <div className="p-4">
-    <h2 className="text-xl font-bold mb-4">Auto Line Movement Configuration</h2>
-    <div className="bg-white rounded-md shadow p-4">
-      <p className="text-sm text-gray-500 mb-4">
-        Configure the Auto Line Movement model settings, including thresholds, market applicability, and response
-        parameters.
-      </p>
-
-      <div className="space-y-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="border rounded-md p-4">
-            <h3 className="font-medium mb-2">Default Parameters</h3>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <span className="text-sm">Liability Threshold</span>
-                <span className="text-sm font-medium">65%</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm">Max Movement</span>
-                <span className="text-sm font-medium">15 cents</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm">Cooldown Period</span>
-                <span className="text-sm font-medium">5 minutes</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="border rounded-md p-4">
-            <h3 className="font-medium mb-2">Model Performance</h3>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <span className="text-sm">Accuracy</span>
-                <span className="text-sm font-medium text-green-600">92.4%</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm">Average Response Time</span>
-                <span className="text-sm font-medium">1.2 seconds</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm">Last Calibration</span>
-                <span className="text-sm font-medium">Today, 09:15 AM</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="border rounded-md p-4">
-          <h3 className="font-medium mb-2">Market Coverage</h3>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-            <div className="border rounded p-2 text-center bg-green-50 border-green-200">
-              <div className="text-xs text-green-800">NBA</div>
-              <div className="text-sm font-medium">Enabled</div>
-            </div>
-            <div className="border rounded p-2 text-center bg-green-50 border-green-200">
-              <div className="text-xs text-green-800">NFL</div>
-              <div className="text-sm font-medium">Enabled</div>
-            </div>
-            <div className="border rounded p-2 text-center bg-yellow-50 border-yellow-200">
-              <div className="text-xs text-yellow-800">MLB</div>
-              <div className="text-sm font-medium">Partial</div>
-            </div>
-            <div className="border rounded p-2 text-center bg-gray-50 border-gray-200">
-              <div className="text-xs text-gray-800">NCAAF</div>
-              <div className="text-sm font-medium">Disabled</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-)
 
 const BlenderWeightingConfig = () => (
   <div className="p-4">
@@ -344,7 +271,7 @@ export default function ModelConfigurationPage() {
           </TabsList>
 
           <TabsContent value="alm">
-            <AutoLineMovementConfig />
+            <AutoLineMovementView />
           </TabsContent>
 
           <TabsContent value="blender">

--- a/app/model-configuration/page.tsx
+++ b/app/model-configuration/page.tsx
@@ -3,6 +3,98 @@
 import { useState } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import TopNavigation from "@/components/top-navigation"
+import { Card, CardContent } from "@/components/ui/card"
+import { Select, SelectTrigger, SelectContent, SelectItem } from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+import { sportsData } from "@/features/auto-line-mover/data"
+
+const mockMarkets = sportsData
+  .flatMap((sport) => sport.categories.flatMap((c) => c.markets))
+  .slice(0, 8)
+  .map((m, idx) => ({
+    marketId: m.id,
+    event: m.name,
+    startTime: `2025-09-15T20:${(25 + idx).toString().padStart(2, "0")}:00Z`,
+    currentPrice: +(2.25 + idx * 0.05).toFixed(2),
+    simPrice: +(2.1 + idx * 0.05).toFixed(2),
+    lean: idx % 2 === 0 ? "Over" : "Under",
+    confidence: {
+      value: "Medium",
+      source: "Sim",
+      setBy: "System",
+      updatedAt: "2025-06-16T09:22:10Z",
+    },
+    endorsed: true,
+  }))
+
+const confidenceColors: Record<string, string> = {
+  High: 'bg-green-500',
+  Medium: 'bg-yellow-400',
+  Low: 'bg-red-500',
+}
+
+function ConfidenceInputUI() {
+  const [markets, setMarkets] = useState(mockMarkets)
+
+  const handleConfidenceChange = (marketId: string, newConfidence: string) => {
+    const updated = markets.map((market) =>
+      market.marketId === marketId
+        ? {
+            ...market,
+            confidence: {
+              value: newConfidence,
+              source: 'Manual',
+              setBy: 'Trader1',
+              updatedAt: new Date().toISOString(),
+            },
+          }
+        : market
+    )
+    setMarkets(updated)
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      {markets.map((market) => (
+        <Card key={market.marketId}>
+          <CardContent className="grid grid-cols-6 items-center gap-4">
+            <div className="col-span-1 font-semibold">{market.event}</div>
+            <div className="col-span-1 text-sm text-gray-500">
+              {new Date(market.startTime).toLocaleString()}
+            </div>
+            <div className="col-span-1">Current Price: {market.currentPrice}</div>
+            <div className="col-span-1">Lean: {market.lean}</div>
+            <div className="col-span-1 flex items-center gap-2">
+              <Badge className={confidenceColors[market.confidence.value]}>
+                {market.confidence.value}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                ({market.confidence.source})
+              </span>
+            </div>
+            <div className="col-span-1">
+              <Select
+                onValueChange={(val) =>
+                  handleConfidenceChange(market.marketId, val)
+                }
+                defaultValue={market.confidence.value}
+              >
+                <SelectTrigger className="w-[120px]">
+                  {market.confidence.value}
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="High">High</SelectItem>
+                  <SelectItem value="Medium">Medium</SelectItem>
+                  <SelectItem value="Low">Low</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
 
 // Placeholder components for the Model Configuration sections
 const AutoLineMovementConfig = () => (
@@ -154,6 +246,7 @@ const BlenderWeightingConfig = () => (
             </div>
           </div>
         </div>
+        <ConfidenceInputUI />
       </div>
     </div>
   </div>

--- a/features/auto-line-mover/components/MarketToggleGrid.tsx
+++ b/features/auto-line-mover/components/MarketToggleGrid.tsx
@@ -4,117 +4,11 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import type { AutoLineMovementMode } from "../types"
+import type { SportData } from "../data"
+import { sportsData } from "../data"
 import { HelpCircle } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
-// Sample data structure
-interface MarketCategory {
-  name: string
-  markets: Market[]
-}
-
-interface Market {
-  id: string
-  name: string
-  status: AutoLineMovementMode
-}
-
-interface SportData {
-  id: string
-  name: string
-  categories: MarketCategory[]
-}
-
-// Sample sports data
-const sportsData: SportData[] = [
-  {
-    id: "basketball",
-    name: "Basketball",
-    categories: [
-      {
-        name: "Main Markets",
-        markets: [
-          { id: "basketball-moneyline", name: "Moneyline", status: "Automatic" },
-          { id: "basketball-spread", name: "Spread", status: "Automatic" },
-          { id: "basketball-totals", name: "Totals", status: "Recommendation" },
-          { id: "basketball-alt-spread", name: "Alt Spread", status: "Disabled" },
-          { id: "basketball-alt-totals", name: "Alt Totals", status: "Disabled" },
-        ],
-      },
-      {
-        name: "Player Props",
-        markets: [
-          { id: "basketball-player-points", name: "Points", status: "Automatic" },
-          { id: "basketball-player-rebounds", name: "Rebounds", status: "Recommendation" },
-          { id: "basketball-player-assists", name: "Assists", status: "Recommendation" },
-          { id: "basketball-player-threes", name: "3-Pointers", status: "Disabled" },
-          { id: "basketball-player-steals", name: "Steals", status: "Disabled" },
-          { id: "basketball-player-blocks", name: "Blocks", status: "Disabled" },
-        ],
-      },
-      {
-        name: "Team Props",
-        markets: [
-          { id: "basketball-team-points", name: "Team Points", status: "Automatic" },
-          { id: "basketball-team-1h-points", name: "1H Points", status: "Recommendation" },
-          { id: "basketball-team-2h-points", name: "2H Points", status: "Recommendation" },
-          { id: "basketball-team-1q-points", name: "1Q Points", status: "Disabled" },
-        ],
-      },
-    ],
-  },
-  {
-    id: "football",
-    name: "Football",
-    categories: [
-      {
-        name: "Main Markets",
-        markets: [
-          { id: "football-moneyline", name: "Moneyline", status: "Automatic" },
-          { id: "football-spread", name: "Spread", status: "Automatic" },
-          { id: "football-totals", name: "Totals", status: "Recommendation" },
-          { id: "football-alt-spread", name: "Alt Spread", status: "Disabled" },
-          { id: "football-alt-totals", name: "Alt Totals", status: "Disabled" },
-        ],
-      },
-      {
-        name: "Player Props",
-        markets: [
-          { id: "football-player-passing", name: "Passing Yards", status: "Automatic" },
-          { id: "football-player-rushing", name: "Rushing Yards", status: "Recommendation" },
-          { id: "football-player-receiving", name: "Receiving Yards", status: "Recommendation" },
-          { id: "football-player-touchdowns", name: "Touchdowns", status: "Disabled" },
-          { id: "football-player-completions", name: "Completions", status: "Disabled" },
-        ],
-      },
-    ],
-  },
-  {
-    id: "baseball",
-    name: "Baseball",
-    categories: [
-      {
-        name: "Main Markets",
-        markets: [
-          { id: "baseball-moneyline", name: "Moneyline", status: "Automatic" },
-          { id: "baseball-runline", name: "Run Line", status: "Automatic" },
-          { id: "baseball-totals", name: "Totals", status: "Recommendation" },
-          { id: "baseball-alt-runline", name: "Alt Run Line", status: "Disabled" },
-          { id: "baseball-alt-totals", name: "Alt Totals", status: "Disabled" },
-        ],
-      },
-      {
-        name: "Player Props",
-        markets: [
-          { id: "baseball-player-hits", name: "Hits", status: "Automatic" },
-          { id: "baseball-player-strikeouts", name: "Strikeouts", status: "Recommendation" },
-          { id: "baseball-player-homeruns", name: "Home Runs", status: "Disabled" },
-          { id: "baseball-player-rbis", name: "RBIs", status: "Disabled" },
-        ],
-      },
-    ],
-  },
-]
 
 export function MarketToggleGrid() {
   const [sports, setSports] = useState<SportData[]>(sportsData)

--- a/features/auto-line-mover/data.ts
+++ b/features/auto-line-mover/data.ts
@@ -1,0 +1,108 @@
+import type { AutoLineMovementMode } from "./types"
+
+export interface Market {
+  id: string
+  name: string
+  status: AutoLineMovementMode
+}
+
+export interface MarketCategory {
+  name: string
+  markets: Market[]
+}
+
+export interface SportData {
+  id: string
+  name: string
+  categories: MarketCategory[]
+}
+
+export const sportsData: SportData[] = [
+  {
+    id: "basketball",
+    name: "Basketball",
+    categories: [
+      {
+        name: "Main Markets",
+        markets: [
+          { id: "basketball-moneyline", name: "Moneyline", status: "Automatic" },
+          { id: "basketball-spread", name: "Spread", status: "Automatic" },
+          { id: "basketball-totals", name: "Totals", status: "Recommendation" },
+          { id: "basketball-alt-spread", name: "Alt Spread", status: "Disabled" },
+          { id: "basketball-alt-totals", name: "Alt Totals", status: "Disabled" },
+        ],
+      },
+      {
+        name: "Player Props",
+        markets: [
+          { id: "basketball-player-points", name: "Points", status: "Automatic" },
+          { id: "basketball-player-rebounds", name: "Rebounds", status: "Recommendation" },
+          { id: "basketball-player-assists", name: "Assists", status: "Recommendation" },
+          { id: "basketball-player-threes", name: "3-Pointers", status: "Disabled" },
+          { id: "basketball-player-steals", name: "Steals", status: "Disabled" },
+          { id: "basketball-player-blocks", name: "Blocks", status: "Disabled" },
+        ],
+      },
+      {
+        name: "Team Props",
+        markets: [
+          { id: "basketball-team-points", name: "Team Points", status: "Automatic" },
+          { id: "basketball-team-1h-points", name: "1H Points", status: "Recommendation" },
+          { id: "basketball-team-2h-points", name: "2H Points", status: "Recommendation" },
+          { id: "basketball-team-1q-points", name: "1Q Points", status: "Disabled" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "football",
+    name: "Football",
+    categories: [
+      {
+        name: "Main Markets",
+        markets: [
+          { id: "football-moneyline", name: "Moneyline", status: "Automatic" },
+          { id: "football-spread", name: "Spread", status: "Automatic" },
+          { id: "football-totals", name: "Totals", status: "Recommendation" },
+          { id: "football-alt-spread", name: "Alt Spread", status: "Disabled" },
+          { id: "football-alt-totals", name: "Alt Totals", status: "Disabled" },
+        ],
+      },
+      {
+        name: "Player Props",
+        markets: [
+          { id: "football-player-passing", name: "Passing Yards", status: "Automatic" },
+          { id: "football-player-rushing", name: "Rushing Yards", status: "Recommendation" },
+          { id: "football-player-receiving", name: "Receiving Yards", status: "Recommendation" },
+          { id: "football-player-touchdowns", name: "Touchdowns", status: "Disabled" },
+          { id: "football-player-completions", name: "Completions", status: "Disabled" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "baseball",
+    name: "Baseball",
+    categories: [
+      {
+        name: "Main Markets",
+        markets: [
+          { id: "baseball-moneyline", name: "Moneyline", status: "Automatic" },
+          { id: "baseball-runline", name: "Run Line", status: "Automatic" },
+          { id: "baseball-totals", name: "Totals", status: "Recommendation" },
+          { id: "baseball-alt-runline", name: "Alt Run Line", status: "Disabled" },
+          { id: "baseball-alt-totals", name: "Alt Totals", status: "Disabled" },
+        ],
+      },
+      {
+        name: "Player Props",
+        markets: [
+          { id: "baseball-player-hits", name: "Hits", status: "Automatic" },
+          { id: "baseball-player-strikeouts", name: "Strikeouts", status: "Recommendation" },
+          { id: "baseball-player-homeruns", name: "Home Runs", status: "Disabled" },
+          { id: "baseball-player-rbis", name: "RBIs", status: "Disabled" },
+        ],
+      },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary
- share sportsData across components
- use sportsData to populate market confidence list

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685532543e088328ac751ae32e122f5e