### PR TITLE
Add persistent market confidence store

### DIFF
--- a/app/blender-weighting/page.tsx
+++ b/app/blender-weighting/page.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import TopNavigation from "@/components/top-navigation"
+import { useMarketConfidence } from "@/hooks/useMarketConfidence"
+import { mockMarkets } from "@/lib/mockMarkets"
+
+export default function BlenderWeightingPage() {
+  const { markets } = useMarketConfidence(mockMarkets)
+
+  return (
+    <div className="min-h-screen bg-[#f8f9fa]">
+      <TopNavigation />
+      <div className="container mx-auto py-6">
+        <h1 className="text-2xl font-bold mb-6">Blender Weighting</h1>
+        <div className="space-y-4">
+          {markets.map((m) => (
+            <div key={m.marketId} className="flex items-center gap-4">
+              <div className="w-48 font-medium">{m.event}</div>
+              <Badge>{m.confidence.value}</Badge>
+              <span className="text-xs text-muted-foreground">({m.confidence.source})</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/model-configuration/page.tsx
+++ b/app/model-configuration/page.tsx
@@ -1,30 +1,14 @@
 "use client"
 
 import { useState } from "react"
+import { useMarketConfidence } from "@/hooks/useMarketConfidence"
+import { mockMarkets } from "@/lib/mockMarkets"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import TopNavigation from "@/components/top-navigation"
 import { Card, CardContent } from "@/components/ui/card"
 import { Select, SelectTrigger, SelectContent, SelectItem } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import { AutoLineMovementView } from "@/features/auto-line-mover"
-
-const mockMarkets = [
-  {
-    marketId: 'nfl.1234.ou25',
-    event: 'NYG vs DAL',
-    startTime: '2025-09-15T20:25:00Z',
-    currentPrice: 2.25,
-    simPrice: 2.10,
-    lean: 'Over',
-    confidence: {
-      value: 'Medium',
-      source: 'Sim',
-      setBy: 'System',
-      updatedAt: '2025-06-16T09:22:10Z',
-    },
-    endorsed: true,
-  },
-]
 
 const confidenceColors: Record<string, string> = {
   High: 'bg-green-500',
@@ -33,23 +17,10 @@ const confidenceColors: Record<string, string> = {
 }
 
 function ConfidenceInputUI() {
-  const [markets, setMarkets] = useState(mockMarkets)
+  const { markets, updateConfidence } = useMarketConfidence(mockMarkets)
 
   const handleConfidenceChange = (marketId: string, newConfidence: string) => {
-    const updated = markets.map((market) =>
-      market.marketId === marketId
-        ? {
-            ...market,
-            confidence: {
-              value: newConfidence,
-              source: 'Manual',
-              setBy: 'Trader1',
-              updatedAt: new Date().toISOString(),
-            },
-          }
-        : market
-    )
-    setMarkets(updated)
+    updateConfidence(marketId, newConfidence as any)
   }
 
   return (

--- a/hooks/useMarketConfidence.ts
+++ b/hooks/useMarketConfidence.ts
@@ -1,0 +1,66 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { mockMarkets } from '@/lib/mockMarkets'
+
+type ConfidenceValue = 'High' | 'Medium' | 'Low'
+
+export interface Market {
+  marketId: string
+  event: string
+  startTime: string
+  currentPrice: number
+  simPrice: number
+  lean: string
+  confidence: {
+    value: ConfidenceValue
+    source: string
+    setBy: string
+    updatedAt: string
+  }
+  endorsed: boolean
+}
+
+const STORAGE_KEY = 'market-confidences'
+
+export function useMarketConfidence(initial: Market[] = mockMarkets) {
+  const [markets, setMarkets] = useState<Market[]>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        try {
+          return JSON.parse(stored) as Market[]
+        } catch {
+          /* ignore malformed storage */
+        }
+      }
+    }
+    return initial
+  })
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(markets))
+    }
+  }, [markets])
+
+  const updateConfidence = (marketId: string, newConfidence: ConfidenceValue) => {
+    setMarkets((prev) =>
+      prev.map((m) =>
+        m.marketId === marketId
+          ? {
+              ...m,
+              confidence: {
+                value: newConfidence,
+                source: 'Manual',
+                setBy: 'Trader1',
+                updatedAt: new Date().toISOString(),
+              },
+            }
+          : m,
+      ),
+    )
+  }
+
+  return { markets, updateConfidence }
+}

--- a/lib/mockMarkets.ts
+++ b/lib/mockMarkets.ts
@@ -1,0 +1,17 @@
+export const mockMarkets = [
+  {
+    marketId: 'nfl.1234.ou25',
+    event: 'NYG vs DAL',
+    startTime: '2025-09-15T20:25:00Z',
+    currentPrice: 2.25,
+    simPrice: 2.10,
+    lean: 'Over',
+    confidence: {
+      value: 'Medium',
+      source: 'Sim',
+      setBy: 'System',
+      updatedAt: '2025-06-16T09:22:10Z',
+    },
+    endorsed: true,
+  },
+]


### PR DESCRIPTION
## Summary
- add `useMarketConfidence` hook with `localStorage` persistence
- move mock markets to shared module
- update Model Configuration page to use global confidence state
- add Blender Weighting page to view market confidence values

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685595c0420c83288ae61e311a072245