### PR TITLE
Implement shared market confidence provider

### DIFF
--- a/app/blender-weighting/page.tsx
+++ b/app/blender-weighting/page.tsx
@@ -2,12 +2,11 @@
 
 import { Badge } from "@/components/ui/badge";
 import TopNavigation from "@/components/top-navigation";
-import { useMarketConfidence } from "@/hooks/useMarketConfidence";
-import { mockMarkets } from "@/lib/mockMarkets";
+import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 import ConfidenceSummary from "@/components/confidence-summary";
 
 export default function BlenderWeightingPage() {
-  const { markets } = useMarketConfidence(mockMarkets);
+  const { markets } = useMarketConfidenceContext();
 
   return (
     <div className="min-h-screen bg-[#f8f9fa]">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
+import { MarketConfidenceProvider } from "@/components/market-confidence-provider"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -21,7 +22,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
-          {children}
+          <MarketConfidenceProvider>
+            {children}
+          </MarketConfidenceProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/model-configuration/page.tsx
+++ b/app/model-configuration/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMarketConfidence } from "@/hooks/useMarketConfidence";
-import { mockMarkets } from "@/lib/mockMarkets";
+import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import TopNavigation from "@/components/top-navigation";
 import { Card, CardContent } from "@/components/ui/card";
@@ -24,7 +23,7 @@ const confidenceColors: Record<string, string> = {
 };
 
 function ConfidenceInputUI() {
-  const { markets, updateConfidence } = useMarketConfidence(mockMarkets);
+  const { markets, updateConfidence } = useMarketConfidenceContext();
 
   const handleConfidenceChange = (marketId: string, newConfidence: string) => {
     updateConfidence(marketId, newConfidence as any);

--- a/components/confidence-summary.tsx
+++ b/components/confidence-summary.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useMarketConfidence } from "@/hooks/useMarketConfidence";
-import { mockMarkets } from "@/lib/mockMarkets";
+import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 import { summarizeBySport } from "@/lib/confidenceSummary";
 
 export default function ConfidenceSummary() {
-  const { markets } = useMarketConfidence(mockMarkets);
+  const { markets } = useMarketConfidenceContext();
   const summary = summarizeBySport(markets);
   const sports = Object.keys(summary);
   if (sports.length === 0) return null;

--- a/components/market-confidence-provider.tsx
+++ b/components/market-confidence-provider.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import React, { createContext, useContext } from 'react'
+import { useMarketConfidence, Market } from '@/hooks/useMarketConfidence'
+import { mockMarkets } from '@/lib/mockMarkets'
+
+interface ContextValue {
+  markets: Market[]
+  updateConfidence: (marketId: string, value: any) => void
+}
+
+const MarketConfidenceContext = createContext<ContextValue | undefined>(undefined)
+
+export function MarketConfidenceProvider({ children }: { children: React.ReactNode }) {
+  const { markets, updateConfidence } = useMarketConfidence(mockMarkets)
+
+  return (
+    <MarketConfidenceContext.Provider value={{ markets, updateConfidence }}>
+      {children}
+    </MarketConfidenceContext.Provider>
+  )
+}
+
+export function useMarketConfidenceContext() {
+  const ctx = useContext(MarketConfidenceContext)
+  if (!ctx) {
+    throw new Error('useMarketConfidenceContext must be used within MarketConfidenceProvider')
+  }
+  return ctx
+}

--- a/components/market-confidence-selector.tsx
+++ b/components/market-confidence-selector.tsx
@@ -1,15 +1,14 @@
 "use client"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { useMarketConfidence } from "@/hooks/useMarketConfidence";
-import { mockMarkets } from "@/lib/mockMarkets";
+import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 
 interface MarketConfidenceSelectorProps {
   marketId: string;
 }
 
 export default function MarketConfidenceSelector({ marketId }: MarketConfidenceSelectorProps) {
-  const { markets, updateConfidence } = useMarketConfidence(mockMarkets);
+  const { markets, updateConfidence } = useMarketConfidenceContext();
   const market = markets.find((m) => m.marketId === marketId);
 
   if (!market) return null;


### PR DESCRIPTION
## Summary
- create `MarketConfidenceProvider` context
- wrap layout with the provider
- update pages and components to use the shared context

## Testing
- `pnpm lint` *(fails: ESLint not configured)*
- `pnpm build` *(fails: blocked font download)*

------
https://chatgpt.com/codex/tasks/task_e_68595555c7748328a4f874b6fe1ed6d3