### PR TITLE
Export ConfidenceValue type and update components

### DIFF
--- a/app/model-configuration/page.tsx
+++ b/app/model-configuration/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
+import { ConfidenceValue } from "@/hooks/useMarketConfidence";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import TopNavigation from "@/components/top-navigation";
 import { Card, CardContent } from "@/components/ui/card";
@@ -25,8 +26,11 @@ const confidenceColors: Record<string, string> = {
 function ConfidenceInputUI() {
   const { markets, updateConfidence } = useMarketConfidenceContext();
 
-  const handleConfidenceChange = (marketId: string, newConfidence: string) => {
-    updateConfidence(marketId, newConfidence as any);
+  const handleConfidenceChange = (
+    marketId: string,
+    newConfidence: ConfidenceValue,
+  ) => {
+    updateConfidence(marketId, newConfidence);
   };
 
   return (
@@ -51,12 +55,15 @@ function ConfidenceInputUI() {
               </span>
             </div>
             <div className="col-span-1">
-              <Select
-                value={market.confidence.value}
-                onValueChange={(val) =>
-                  handleConfidenceChange(market.marketId, val)
-                }
-              >
+                <Select
+                  value={market.confidence.value}
+                  onValueChange={(val) =>
+                    handleConfidenceChange(
+                      market.marketId,
+                      val as ConfidenceValue,
+                    )
+                  }
+                >
                 <SelectTrigger className="w-[120px]">
                   <SelectValue placeholder="Select" />
                 </SelectTrigger>

--- a/components/market-confidence-provider.tsx
+++ b/components/market-confidence-provider.tsx
@@ -1,12 +1,16 @@
 "use client"
 
 import React, { createContext, useContext } from 'react'
-import { useMarketConfidence, Market } from '@/hooks/useMarketConfidence'
+import {
+  useMarketConfidence,
+  Market,
+  ConfidenceValue,
+} from '@/hooks/useMarketConfidence'
 import { mockMarkets } from '@/lib/mockMarkets'
 
 interface ContextValue {
   markets: Market[]
-  updateConfidence: (marketId: string, value: any) => void
+  updateConfidence: (marketId: string, value: ConfidenceValue) => void
 }
 
 const MarketConfidenceContext = createContext<ContextValue | undefined>(undefined)

--- a/components/market-confidence-selector.tsx
+++ b/components/market-confidence-selector.tsx
@@ -2,6 +2,7 @@
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
+import { ConfidenceValue } from "@/hooks/useMarketConfidence";
 
 interface MarketConfidenceSelectorProps {
   marketId: string;
@@ -18,7 +19,7 @@ export default function MarketConfidenceSelector({ marketId }: MarketConfidenceS
       <Badge>{market.confidence.value}</Badge>
       <Select
         value={market.confidence.value}
-        onValueChange={(val) => updateConfidence(marketId, val as any)}
+        onValueChange={(val) => updateConfidence(marketId, val as ConfidenceValue)}
       >
         <SelectTrigger className="w-[100px]">
           <SelectValue placeholder="Confidence" />

--- a/hooks/useMarketConfidence.ts
+++ b/hooks/useMarketConfidence.ts
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { mockMarkets } from '@/lib/mockMarkets'
 
-type ConfidenceValue = 'High' | 'Medium' | 'Low'
+export type ConfidenceValue = 'High' | 'Medium' | 'Low'
 
 export interface Market {
   marketId: string


### PR DESCRIPTION
## Summary
- export `ConfidenceValue` from `useMarketConfidence`
- use `ConfidenceValue` in market confidence provider
- update selector and configuration pages to use `ConfidenceValue`

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_685a5c6cbda083289688a02102aeb2b8