### PR TITLE
Add confidence inputs to fixture pages

### DIFF
--- a/app/blender-weighting/page.tsx
+++ b/app/blender-weighting/page.tsx
@@ -2,12 +2,11 @@
 
 import { Badge } from "@/components/ui/badge";
 import TopNavigation from "@/components/top-navigation";
-import { useMarketConfidence } from "@/hooks/useMarketConfidence";
-import { mockMarkets } from "@/lib/mockMarkets";
+import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 import ConfidenceSummary from "@/components/confidence-summary";
 
 export default function BlenderWeightingPage() {
-  const { markets } = useMarketConfidence(mockMarkets);
+  const { markets } = useMarketConfidenceContext();
 
   return (
     <div className="min-h-screen bg-[#f8f9fa]">

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -1361,6 +1361,9 @@ export default function GamePage() {
                         </tbody>
                       </table>
                     </div>
+                    <div className="p-3 border-t">
+                      <MarketConfidenceSelector marketId="nba.fixture.moneyline" />
+                    </div>
                   </div>
                 )}
               </div>
@@ -1450,6 +1453,9 @@ export default function GamePage() {
                           </tr>
                         </tbody>
                       </table>
+                    </div>
+                    <div className="p-3 border-t">
+                      <MarketConfidenceSelector marketId="nba.fixture.handicap" />
                     </div>
                   </div>
                 )}
@@ -1549,6 +1555,9 @@ export default function GamePage() {
                           </tr>
                         </tbody>
                       </table>
+                    </div>
+                    <div className="p-3 border-t">
+                      <MarketConfidenceSelector marketId="nba.fixture.total" />
                     </div>
                   </div>
                 )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
+import { MarketConfidenceProvider } from "@/components/market-confidence-provider"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -21,7 +22,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
-          {children}
+          <MarketConfidenceProvider>{children}</MarketConfidenceProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/model-configuration/page.tsx
+++ b/app/model-configuration/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMarketConfidence } from "@/hooks/useMarketConfidence";
-import { mockMarkets } from "@/lib/mockMarkets";
+import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import TopNavigation from "@/components/top-navigation";
 import { Card, CardContent } from "@/components/ui/card";
@@ -24,7 +23,7 @@ const confidenceColors: Record<string, string> = {
 };
 
 function ConfidenceInputUI() {
-  const { markets, updateConfidence } = useMarketConfidence(mockMarkets);
+  const { markets, updateConfidence } = useMarketConfidenceContext();
 
   const handleConfidenceChange = (marketId: string, newConfidence: string) => {
     updateConfidence(marketId, newConfidence as any);

--- a/app/nfl-game/page.tsx
+++ b/app/nfl-game/page.tsx
@@ -437,6 +437,9 @@ export default function NflGamePage() {
                         <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                           Status
                         </th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          Confidence
+                        </th>
                       </tr>
                     </thead>
                     <tbody className="bg-white divide-y divide-gray-200">
@@ -462,6 +465,9 @@ export default function NflGamePage() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           -
                         </td>
+                        <td className="px-6 py-4">
+                          <MarketConfidenceSelector marketId="nfl.1234.moneyline" />
+                        </td>
                       </tr>
                       <tr className="bg-gray-50">
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
@@ -485,12 +491,12 @@ export default function NflGamePage() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           -
                         </td>
+                        <td className="px-6 py-4">
+                          <MarketConfidenceSelector marketId="nfl.1234.moneyline" />
+                        </td>
                       </tr>
                     </tbody>
                   </table>
-                </div>
-                <div className="p-3 border-t">
-                  <MarketConfidenceSelector marketId="nfl.1234.moneyline" />
                 </div>
               </div>
             )}
@@ -536,6 +542,9 @@ export default function NflGamePage() {
                         <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                           Status
                         </th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          Confidence
+                        </th>
                       </tr>
                     </thead>
                     <tbody className="bg-white divide-y divide-gray-200">
@@ -561,6 +570,9 @@ export default function NflGamePage() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           -
                         </td>
+                        <td className="px-6 py-4">
+                          <MarketConfidenceSelector marketId="nfl.1234.spread" />
+                        </td>
                       </tr>
                       <tr className="bg-gray-50">
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
@@ -584,12 +596,12 @@ export default function NflGamePage() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           -
                         </td>
+                        <td className="px-6 py-4">
+                          <MarketConfidenceSelector marketId="nfl.1234.spread" />
+                        </td>
                       </tr>
                     </tbody>
                   </table>
-                </div>
-                <div className="p-3 border-t">
-                  <MarketConfidenceSelector marketId="nfl.1234.spread" />
                 </div>
               </div>
             )}
@@ -635,6 +647,9 @@ export default function NflGamePage() {
                         <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                           Status
                         </th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                          Confidence
+                        </th>
                       </tr>
                     </thead>
                     <tbody className="bg-white divide-y divide-gray-200">
@@ -660,6 +675,9 @@ export default function NflGamePage() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           -
                         </td>
+                        <td className="px-6 py-4">
+                          <MarketConfidenceSelector marketId="nfl.1234.total" />
+                        </td>
                       </tr>
                       <tr className="bg-gray-50">
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
@@ -683,12 +701,12 @@ export default function NflGamePage() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           -
                         </td>
+                        <td className="px-6 py-4">
+                          <MarketConfidenceSelector marketId="nfl.1234.total" />
+                        </td>
                       </tr>
                     </tbody>
                   </table>
-                </div>
-                <div className="p-3 border-t">
-                  <MarketConfidenceSelector marketId="nfl.1234.total" />
                 </div>
               </div>
             )}

--- a/components/confidence-summary.tsx
+++ b/components/confidence-summary.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useMarketConfidence } from "@/hooks/useMarketConfidence";
-import { mockMarkets } from "@/lib/mockMarkets";
+import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 import { summarizeBySport } from "@/lib/confidenceSummary";
 
 export default function ConfidenceSummary() {
-  const { markets } = useMarketConfidence(mockMarkets);
+  const { markets } = useMarketConfidenceContext();
   const summary = summarizeBySport(markets);
   const sports = Object.keys(summary);
   if (sports.length === 0) return null;

--- a/components/market-confidence-provider.tsx
+++ b/components/market-confidence-provider.tsx
@@ -1,0 +1,26 @@
+"use client"
+import React, { createContext, useContext } from "react"
+import { useMarketConfidence, Market } from "@/hooks/useMarketConfidence"
+import { mockMarkets } from "@/lib/mockMarkets"
+
+interface MarketConfidenceContextValue {
+  markets: Market[]
+  updateConfidence: (marketId: string, value: "High" | "Medium" | "Low") => void
+}
+
+const MarketConfidenceContext = createContext<MarketConfidenceContextValue | undefined>(undefined)
+
+export function MarketConfidenceProvider({ children }: { children: React.ReactNode }) {
+  const { markets, updateConfidence } = useMarketConfidence(mockMarkets)
+  return (
+    <MarketConfidenceContext.Provider value={{ markets, updateConfidence }}>
+      {children}
+    </MarketConfidenceContext.Provider>
+  )
+}
+
+export function useMarketConfidenceContext() {
+  const ctx = useContext(MarketConfidenceContext)
+  if (!ctx) throw new Error("useMarketConfidenceContext must be used within MarketConfidenceProvider")
+  return ctx
+}

--- a/components/market-confidence-selector.tsx
+++ b/components/market-confidence-selector.tsx
@@ -1,15 +1,14 @@
 "use client"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { useMarketConfidence } from "@/hooks/useMarketConfidence";
-import { mockMarkets } from "@/lib/mockMarkets";
+import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 
 interface MarketConfidenceSelectorProps {
   marketId: string;
 }
 
 export default function MarketConfidenceSelector({ marketId }: MarketConfidenceSelectorProps) {
-  const { markets, updateConfidence } = useMarketConfidence(mockMarkets);
+  const { markets, updateConfidence } = useMarketConfidenceContext();
   const market = markets.find((m) => m.marketId === marketId);
 
   if (!market) return null;


### PR DESCRIPTION
## Summary
- add `MarketConfidenceProvider` to the app root so every page can access shared confidence data
- let traders set confidence for Moneyline, Handicap and Total markets in the NBA game page
- add confidence input column to NFL fixture tables so traders can rate markets directly

## Testing
- `pnpm install --ignore-scripts`
- `pnpm lint` *(fails: ESLint setup prompt)*
- `pnpm build` *(fails to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685a7b134bec8328817fdaf3f253c2ba