### PR TITLE
Add reusable MarketClassFilter

### DIFF
--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -16,6 +16,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import Sidebar from "@/components/sidebar"
 import TopNavigation from "@/components/top-navigation"
 import MarketConfidenceSelector from "@/components/market-confidence-selector"
+import MarketClassFilter from "@/components/market-class-filter"
 
 export default function GamePage() {
   const [carouselView, setCarouselView] = useState("stats")
@@ -1163,79 +1164,11 @@ export default function GamePage() {
             </div>
 
             <div className="flex flex-wrap gap-2 mb-4 text-sm">
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "all" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("all")}
-                >
-                  All Markets
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "fixture" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("fixture")}
-                >
-                  Fixture Markets
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "player" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("player")}
-                >
-                  Player Matchup Handicap
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "combined" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("combined")}
-                >
-                  Player Combined
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "player-markets" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("player-markets")}
-                >
-                  Player Markets
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "player-matchup" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("player-matchup")}
-                >
-                  Player Matchup
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "player-milestone" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("player-milestone")}
-                >
-                  Player Milestone
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "player-race" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("player-race")}
-                >
-                  Player Race
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span
-                  className={`px-2 py-1 rounded ${activeMarketFilter === "most" ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"}`}
-                  onClick={() => setActiveMarketFilter("most")}
-                >
-                  Player Most
-                </span>
-              </div>
-
+              <MarketClassFilter
+                sport="basketball"
+                active={activeMarketFilter}
+                onChange={(val) => setActiveMarketFilter(val ?? "all")}
+              />
               <div className="ml-auto flex items-center gap-2">
                 <span className="text-xs">Adjusted Only</span>
                 <div className="w-8 h-4 bg-[#dcdddf] rounded-full relative">

--- a/app/nfl-game/page.tsx
+++ b/app/nfl-game/page.tsx
@@ -16,6 +16,7 @@ import { ScoreboardTabs } from "@/features/basketball";
 import Sidebar from "@/components/sidebar";
 import TopNavigation from "@/components/top-navigation";
 import MarketConfidenceSelector from "@/components/market-confidence-selector";
+import MarketClassFilter from "@/components/market-class-filter";
 
 export default function NflGamePage() {
   const [scoreboardTab, setScoreboardTab] = useState(
@@ -332,22 +333,12 @@ export default function NflGamePage() {
           {/* Market Class */}
           <div className="mb-4">
             <h4 className="text-sm font-medium mb-2">Market Class</h4>
-            <div className="flex gap-2 flex-wrap">
-              <div
-                className="flex-1 min-w-[120px] p-2 bg-[#62c11e] bg-opacity-20 border border-[#62c11e] rounded text-center cursor-pointer hover:bg-opacity-30"
-                onClick={() => toggleMarketClassExpansion("fixture")}
-              >
-                <div className="text-xs font-medium">Fixture</div>
-                <div className="text-xs text-[#5f6368]">100% Open</div>
-              </div>
-              <div
-                className="flex-1 min-w-[120px] p-2 bg-[#FFC107] bg-opacity-20 border border-[#FFC107] rounded text-center cursor-pointer hover:bg-opacity-30"
-                onClick={() => toggleMarketClassExpansion("player")}
-              >
-                <div className="text-xs font-medium">Player</div>
-                <div className="text-xs text-[#5f6368]">75% Open</div>
-              </div>
-            </div>
+            <MarketClassFilter
+              sport="football"
+              active={expandedMarketClass}
+              onChange={(val) => toggleMarketClassExpansion(val ?? "")}
+              hideAll
+            />
 
             {expandedMarketClass && (
               <div className="mt-4 border border-[#dcdddf] rounded-md overflow-hidden">

--- a/components/market-class-filter.tsx
+++ b/components/market-class-filter.tsx
@@ -1,0 +1,37 @@
+"use client"
+import { marketClasses, Sport } from "@/features/markets/marketClasses"
+
+interface MarketClassFilterProps {
+  sport: Sport
+  active: string | null
+  onChange?: (value: string | null) => void
+  hideAll?: boolean
+}
+
+export default function MarketClassFilter({
+  sport,
+  active,
+  onChange,
+  hideAll,
+}: MarketClassFilterProps) {
+  const classes = marketClasses[sport] || []
+
+  const renderButton = (id: string, label: string) => (
+    <span
+      key={id}
+      className={`px-2 py-1 rounded cursor-pointer ${
+        active === id ? "bg-[#2b2c2d] text-white" : "border border-[#dcdddf]"
+      }`}
+      onClick={() => onChange?.(id)}
+    >
+      {label}
+    </span>
+  )
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-4 text-sm">
+      {!hideAll && renderButton("all", "All Markets")}
+      {classes.map((c) => renderButton(c.id, c.label))}
+    </div>
+  )
+}

--- a/features/markets/marketClasses.ts
+++ b/features/markets/marketClasses.ts
@@ -1,0 +1,25 @@
+export type Sport = "basketball" | "football"
+
+export interface MarketClass {
+  id: string
+  label: string
+}
+
+export const marketClasses: Record<Sport, MarketClass[]> = {
+  basketball: [
+    { id: "fixture", label: "Fixture Markets" },
+    { id: "player", label: "Player Matchup Handicap" },
+    { id: "combined", label: "Player Combined" },
+    { id: "player-markets", label: "Player Markets" },
+    { id: "player-matchup", label: "Player Matchup" },
+    { id: "player-milestone", label: "Player Milestone" },
+    { id: "player-race", label: "Player Race" },
+    { id: "most", label: "Player Most" },
+  ],
+  football: [
+    { id: "fixture", label: "Fixture Markets" },
+    { id: "player", label: "Player Props" },
+    { id: "passing", label: "Passing Yards" },
+    { id: "receiving", label: "Receiving Yards" },
+  ],
+}


### PR DESCRIPTION
## Summary
- define supported market classes per sport
- implement `MarketClassFilter` component
- use it in NBA and NFL game pages

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68665eff05a88328a3e005c1f47ca023