### PR TITLE
Improve typing for confidence controls

### DIFF
--- a/app/model-configuration/page.tsx
+++ b/app/model-configuration/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { ConfidenceValue } from "@/hooks/useMarketConfidence";
 import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import TopNavigation from "@/components/top-navigation";
@@ -25,8 +26,11 @@ const confidenceColors: Record<string, string> = {
 function ConfidenceInputUI() {
   const { markets, updateConfidence } = useMarketConfidenceContext();
 
-  const handleConfidenceChange = (marketId: string, newConfidence: string) => {
-    updateConfidence(marketId, newConfidence as any);
+  const handleConfidenceChange = (
+    marketId: string,
+    newConfidence: ConfidenceValue,
+  ) => {
+    updateConfidence(marketId, newConfidence);
   };
 
   return (
@@ -53,7 +57,7 @@ function ConfidenceInputUI() {
             <div className="col-span-1">
               <Select
                 value={market.confidence.value}
-                onValueChange={(val) =>
+                onValueChange={(val: ConfidenceValue) =>
                   handleConfidenceChange(market.marketId, val)
                 }
               >
@@ -255,7 +259,9 @@ const CompetitorConfigurationConfig = () => (
 );
 
 export default function ModelConfigurationPage() {
-  const [activeTab, setActiveTab] = useState("alm");
+  const [activeTab, setActiveTab] = useState<'alm' | 'blender' | 'competitor'>(
+    'alm',
+  );
 
   return (
     <div className="min-h-screen bg-[#f8f9fa]">

--- a/components/market-confidence-provider.tsx
+++ b/components/market-confidence-provider.tsx
@@ -1,12 +1,16 @@
 "use client"
 
 import React, { createContext, useContext } from 'react'
-import { useMarketConfidence, Market } from '@/hooks/useMarketConfidence'
+import {
+  useMarketConfidence,
+  Market,
+  ConfidenceValue,
+} from '@/hooks/useMarketConfidence'
 import { mockMarkets } from '@/lib/mockMarkets'
 
 interface ContextValue {
   markets: Market[]
-  updateConfidence: (marketId: string, value: any) => void
+  updateConfidence: (marketId: string, value: ConfidenceValue) => void
 }
 
 const MarketConfidenceContext = createContext<ContextValue | undefined>(undefined)

--- a/components/market-confidence-selector.tsx
+++ b/components/market-confidence-selector.tsx
@@ -2,6 +2,7 @@
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { useMarketConfidenceContext } from "@/components/market-confidence-provider";
+import type { ConfidenceValue } from "@/hooks/useMarketConfidence";
 
 interface MarketConfidenceSelectorProps {
   marketId: string;
@@ -18,7 +19,9 @@ export default function MarketConfidenceSelector({ marketId }: MarketConfidenceS
       <Badge>{market.confidence.value}</Badge>
       <Select
         value={market.confidence.value}
-        onValueChange={(val) => updateConfidence(marketId, val as any)}
+        onValueChange={(val: ConfidenceValue) =>
+          updateConfidence(marketId, val)
+        }
       >
         <SelectTrigger className="w-[100px]">
           <SelectValue placeholder="Confidence" />

--- a/hooks/useMarketConfidence.ts
+++ b/hooks/useMarketConfidence.ts
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { mockMarkets } from '@/lib/mockMarkets'
 
-type ConfidenceValue = 'High' | 'Medium' | 'Low'
+export type ConfidenceValue = 'High' | 'Medium' | 'Low'
 
 export interface Market {
   marketId: string


### PR DESCRIPTION
## Summary
- export `ConfidenceValue` and use it across the app
- type market confidence context and selector
- type confidence controls in model configuration page
- restrict active tab string union

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688096d1bd30832891e8ffe77892a697